### PR TITLE
suppress Lyman alpha emission in high-z spectra

### DIFF
--- a/bagpipes/models/igm_model.py
+++ b/bagpipes/models/igm_model.py
@@ -5,6 +5,16 @@ import numpy as np
 from .. import config
 
 
+def interp_discont(x, xp, fp, xdiscont, left=None, right=None):
+    """Interpolates separately on both sides of a discontinuity (not over it)"""
+    i  = np.searchsorted(x, xdiscont)
+    ip = np.searchsorted(xp, xdiscont)
+    y1 = np.interp(x[:i], xp[:ip], fp[:ip], left=left)
+    y2 = np.interp(x[i:], xp[ip:], fp[ip:], right=right)
+    y  = np.concatenate([y1, y2])
+    return y
+
+
 class igm(object):
     """ Allows access to and maniuplation of the IGM attenuation models
     of Inoue (2014).
@@ -28,8 +38,8 @@ class igm(object):
                          config.igm_redshifts.shape[0]))
 
         for i in range(config.igm_redshifts.shape[0]):
-            grid[:, i] = np.interp(self.wavelengths, config.igm_wavelengths,
-                                   config.raw_igm_grid[i, :],
+            grid[:, i] = interp_discont(self.wavelengths, config.igm_wavelengths,
+                                   config.raw_igm_grid[i, :], 1215.67,
                                    left=0., right=1.)
 
         return grid


### PR DESCRIPTION
I found Lyman alpha persisted in some very high-z galaxies, including z = 11. 

![image](https://user-images.githubusercontent.com/10759262/76459644-f2611a80-63b2-11ea-8e23-1b250cf9b51a.png)

I traced this to an issue interpolating the IGM absorption, which has a discontinuity at Lya: = 1 redward and < 1 blueward. A standard interpolation can yield a data point with absorption < 1 blueward of Lya.

![discontinuity interpolation](https://user-images.githubusercontent.com/10759262/76459584-d78ea600-63b2-11ea-8c5d-187ef079ab7c.png)

I fixed this by performing separate interpolations on either side of Lya in igm_model.py. Now Lya is suppressed at z=11. (And since I normalized my spectrum to the observed flux in F160W which spans Lya, now the predicted NIR fluxes are much higher.)

![image](https://user-images.githubusercontent.com/10759262/76459722-0efd5280-63b3-11ea-9c63-a70c831a2eb2.png)

This issue seems to affect model generation (model_galaxy) but not the fitting (fit).