### PR TITLE
Specify redshift_sigma's prior as Gaussian

### DIFF
--- a/bagpipes/catalogue/fit_catalogue.py
+++ b/bagpipes/catalogue/fit_catalogue.py
@@ -274,6 +274,7 @@ class fit_catalogue(object):
             if self.redshift_sigma > 0.:
                 z = self.redshifts[ind]
                 sig = self.redshift_sigma
+                self.fit_instructions["redshift_prior"] = "Gaussian"
                 self.fit_instructions["redshift_prior_mu"] = z
                 self.fit_instructions["redshift_prior_sigma"] = sig
                 self.fit_instructions["redshift"] = (z - 3*sig, z + 3*sig)


### PR DESCRIPTION
Fitting fit_catalogue with redshift_sigma did not specify the redshift's prior as Gaussian, so BAGPIPES defaulted to a uniform prior. I inserted a line to specify fit_catalogue's prior for the redshift with redshift_sigma as Gaussian.