### PR TITLE
Fix syntax warnings

### DIFF
--- a/bagpipes/catalogue/fit_catalogue.py
+++ b/bagpipes/catalogue/fit_catalogue.py
@@ -335,10 +335,10 @@ class fit_catalogue(object):
 
             for v in self.vars:
 
-                if v is "UV_colour":
+                if v == "UV_colour":
                     values = samples["uvj"][:, 0] - samples["uvj"][:, 1]
 
-                elif v is "VJ_colour":
+                elif v == "VJ_colour":
                     values = samples["uvj"][:, 1] - samples["uvj"][:, 2]
 
                 else:

--- a/bagpipes/input/galaxy.py
+++ b/bagpipes/input/galaxy.py
@@ -213,13 +213,13 @@ class galaxy:
         mask = np.loadtxt("masks/" + self.ID + "_mask")
         if len(mask.shape) == 1:
             wl_mask = (spec[:, 0] > mask[0]) & (spec[:, 0] < mask[1])
-            if spec[wl_mask, 2].shape[0] is not 0:
+            if spec[wl_mask, 2].shape[0] != 0:
                 spec[wl_mask, 2] = 9.9*10**99.
 
         if len(mask.shape) == 2:
             for i in range(mask.shape[0]):
                 wl_mask = (spec[:, 0] > mask[i, 0]) & (spec[:, 0] < mask[i, 1])
-                if spec[wl_mask, 2].shape[0] is not 0:
+                if spec[wl_mask, 2].shape[0] != 0:
                     spec[wl_mask, 2] = 9.9*10**99.
 
         return spec

--- a/bagpipes/models/chemical_enrichment_history.py
+++ b/bagpipes/models/chemical_enrichment_history.py
@@ -18,7 +18,7 @@ class chemical_enrichment_history(object):
                               config.age_sampling.shape[0]))
 
         for comp in list(sfh_weights):
-            if comp is not "total":
+            if comp != "total":
                 self.grid_comp[comp] = self.delta(model_comp[comp],
                                                   sfh_weights[comp])
 

--- a/bagpipes/utils.py
+++ b/bagpipes/utils.py
@@ -20,7 +20,7 @@ def make_dirs(run="."):
     if not os.path.exists(working_dir + "/pipes/cats"):
         os.mkdir(working_dir + "/pipes/cats")
 
-    if run is not ".":
+    if run != ".":
         if not os.path.exists("pipes/posterior/" + run):
             os.mkdir("pipes/posterior/" + run)
 


### PR DESCRIPTION
Python 3.8+ now produces a `SyntaxWarning` for identity checks, i.e., `is` instead of `==` (https://docs.python.org/3.8/whatsnew/3.8.html#porting-to-python-3-8).  This PR fixes those syntax issues.