### PR TITLE
Fix deprecated scipy namespace

### DIFF
--- a/bagpipes/plotting/general.py
+++ b/bagpipes/plotting/general.py
@@ -10,7 +10,7 @@ except RuntimeError:
     pass
 
 from distutils.spawn import find_executable
-from scipy.ndimage.filters import gaussian_filter
+from scipy.ndimage import gaussian_filter
 
 from .. import utils
 


### PR DESCRIPTION
The `scipy.ndimage.filters` namespace was deprecated in scipy 1.8.0.

```python
>>> from scipy.ndimage.filters import gaussian_filter
DeprecationWarning: Please use `gaussian_filter` from the `scipy.ndimage` namespace, the `scipy.ndimage.filters` namespace is deprecated.
```