### PR TITLE
Fix deprecated numpy behavior when using R_curve

### DIFF
--- a/bagpipes/fitting/fitted_model.py
+++ b/bagpipes/fitting/fitted_model.py
@@ -96,18 +96,18 @@ class fitted_model(object):
                             hyp_key = all_keys[i][len(prior_key)+1:]
                             self.hyper_params[-1][hyp_key] = all_vals[i]
 
-            # Find any parameters which mirror the value of a fit param.
-            if all_vals[i] in all_keys:
-                self.mirror_pars[all_keys[i]] = all_vals[i]
-
-            if all_vals[i] == "dirichlet":
-                n = all_vals[all_keys.index(all_keys[i][:-6])]
-                comp = all_keys[i].split(":")[0]
-                for j in range(1, n):
-                    self.params.append(comp + ":dirichletr" + str(j))
-                    self.pdfs.append("uniform")
-                    self.limits.append((0., 1.))
-                    self.hyper_params.append({})
+                # Find any parameters which mirror the value of a fit param.
+                if all_vals[i] in all_keys:
+                    self.mirror_pars[all_keys[i]] = all_vals[i]
+    
+                if all_vals[i] == "dirichlet":
+                    n = all_vals[all_keys.index(all_keys[i][:-6])]
+                    comp = all_keys[i].split(":")[0]
+                    for j in range(1, n):
+                        self.params.append(comp + ":dirichletr" + str(j))
+                        self.pdfs.append("uniform")
+                        self.limits.append((0., 1.))
+                        self.hyper_params.append({})
 
         # Find the dimensionality of the fit
         self.ndim = len(self.params)

--- a/bagpipes/fitting/fitted_model.py
+++ b/bagpipes/fitting/fitted_model.py
@@ -75,24 +75,26 @@ class fitted_model(object):
 
         # Find parameters to be fitted and extract their priors.
         for i in range(len(all_vals)):
-            if isinstance(all_vals[i], tuple):
-                self.params.append(all_keys[i])
-                self.limits.append(all_vals[i])  # Limits on prior.
-
-                # Prior probability densities between these limits.
-                prior_key = all_keys[i] + "_prior"
-                if prior_key in list(all_keys):
-                    self.pdfs.append(all_vals[all_keys.index(prior_key)])
-
-                else:
-                    self.pdfs.append("uniform")
-
-                # Any hyper-parameters of these prior distributions.
-                self.hyper_params.append({})
-                for i in range(len(all_keys)):
-                    if all_keys[i].startswith(prior_key + "_"):
-                        hyp_key = all_keys[i][len(prior_key)+1:]
-                        self.hyper_params[-1][hyp_key] = all_vals[i]
+            # R_curve cannot be fitted and is either unset or must be a 2D numpy array
+            if not all_keys[i] == 'R_curve':
+                if isinstance(all_vals[i], tuple):
+                    self.params.append(all_keys[i])
+                    self.limits.append(all_vals[i])  # Limits on prior.
+    
+                    # Prior probability densities between these limits.
+                    prior_key = all_keys[i] + "_prior"
+                    if prior_key in list(all_keys):
+                        self.pdfs.append(all_vals[all_keys.index(prior_key)])
+    
+                    else:
+                        self.pdfs.append("uniform")
+    
+                    # Any hyper-parameters of these prior distributions.
+                    self.hyper_params.append({})
+                    for i in range(len(all_keys)):
+                        if all_keys[i].startswith(prior_key + "_"):
+                            hyp_key = all_keys[i][len(prior_key)+1:]
+                            self.hyper_params[-1][hyp_key] = all_vals[i]
 
             # Find any parameters which mirror the value of a fit param.
             if all_vals[i] in all_keys:


### PR DESCRIPTION
Since Numpy 1.25.0 a previous warning behavior has become deprecated.

In particular '==' and 'in' have been redefined to match the Python meaning when there are arrays to the left of the operators.

This broke a part of the code where the value of the R_curve array (which is a 2D array) was checked if it was equal to the name of another key in the fit parameters or equal to "dirichlet".

This commit skip these comparison when the key is R_curve.

Solve #60 