### PR TITLE
Better nautilus integration

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ Bagpipes can be installed with pip:
 
     pip install bagpipes
 
-Please note you cannot run the code just by cloning the repository as the large grids of models aren't included. To fit models to data with the code you may also install the `MultiNest <https://github.com/JohannesBuchner/MultiNest>`_. If MultiNest is not installed, `nautilus <https://github.com/johannesulf/nautilus>`_ will be used for fitting. For more information please see the `bagpipes documentation <http://bagpipes.readthedocs.io>`_.
+Please note you cannot run the code just by cloning the repository as the large grids of models aren't included. To fit models to data with the code you may also install the `MultiNest <https://github.com/JohannesBuchner/MultiNest>`_ code. If MultiNest is not installed, `nautilus <https://github.com/johannesulf/nautilus>`_ will be used for fitting. For more information please see the `bagpipes documentation <http://bagpipes.readthedocs.io>`_.
 
 **Published papers and citing the code**
 

--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ Bagpipes can be installed with pip:
 
     pip install bagpipes
 
-Please note you cannot run the code just by cloning the repository as the large grids of models aren't included. To fit models to data with the code you will also need to install the `MultiNest <https://github.com/JohannesBuchner/MultiNest>`_ code. For more information please see the `bagpipes documentation <http://bagpipes.readthedocs.io>`_.
+Please note you cannot run the code just by cloning the repository as the large grids of models aren't included. To fit models to data with the code you may also install the `MultiNest <https://github.com/JohannesBuchner/MultiNest>`_. If MultiNest is not installed, `nautilus <https://github.com/johannesulf/nautilus>`_ will be used for fitting. For more information please see the `bagpipes documentation <http://bagpipes.readthedocs.io>`_.
 
 **Published papers and citing the code**
 

--- a/bagpipes/config.py
+++ b/bagpipes/config.py
@@ -112,10 +112,12 @@ try:
     logU = np.arange(-4., -1.99, 0.5)
 
     # Grid of line fluxes.
-    line_grid = fits.open(grid_dir + "/" + neb_line_file)
+    line_grid = [fits.open(grid_dir + "/" + neb_line_file)[i].data for
+                 i in range(len(metallicities) * len(logU) + 1)]
 
     # Grid of nebular continuum fluxes.
-    cont_grid = fits.open(grid_dir + "/" + neb_cont_file)
+    cont_grid = [fits.open(grid_dir + "/" + neb_cont_file)[i].data for
+                 i in range(len(metallicities) * len(logU) + 1)]
 
 except IOError:
     print("Failed to load nebular grids, these should be placed in the"
@@ -136,9 +138,13 @@ try:
                           2.37, 2.50, 3.19, 3.90, 4.58])
 
     # Draine + Li (2007) dust emission grids, stored as a FITS HDUList.
-    dust_grid_umin_only = fits.open(grid_dir + "/dl07_grids_umin_only.fits")
+    dust_grid_umin_only = [
+        fits.open(grid_dir + "/dl07_grids_umin_only.fits")[i].data for i
+        in range(len(qpah_vals) + 1)]
 
-    dust_grid_umin_umax = fits.open(grid_dir + "/dl07_grids_umin_umax.fits")
+    dust_grid_umin_umax = [
+        fits.open(grid_dir + "/dl07_grids_umin_umax.fits")[i].data for i
+        in range(len(qpah_vals) + 1)]
 
 except IOError:
     print("Failed to load dust emission grids, these should be placed in the"

--- a/bagpipes/fitting/fit.py
+++ b/bagpipes/fitting/fit.py
@@ -213,8 +213,12 @@ class fit(object):
                 self.results["lnz_err"] = float(lnz_line[-1])
 
             elif sampler == "nautilus":
-                samples2d, log_w, log_l = n_sampler.posterior(
-                    equal_weight=True)
+                samples2d = np.zeros((0, self.fitted_model.ndim))
+                log_l = np.zeros(0)
+                while len(samples2d) < self.n_posterior:
+                    result = n_sampler.posterior(equal_weight=True)
+                    samples2d = np.vstack((samples2d, result[0]))
+                    log_l = np.concatenate((log_l, result[2]))
                 self.results["samples2d"] = samples2d
                 self.results["lnlike"] = log_l
                 self.results["lnz"] = n_sampler.log_z

--- a/bagpipes/fitting/fit.py
+++ b/bagpipes/fitting/fit.py
@@ -10,15 +10,19 @@ from copy import deepcopy
 
 try:
     import pymultinest as pmn
-
-except (ImportError, RuntimeError, SystemExit) as e:
-    print("Bagpipes: PyMultiNest import failed, fitting will be unavailable.")
+    multinest_available = True
+except (ImportError, RuntimeError, SystemExit):
+    print("Bagpipes: PyMultiNest import failed, fitting with MultiNest will " +
+          "be unavailable.")
+    multinest_available = False
 
 try:
     from nautilus import Sampler
-
-except (ImportError, RuntimeError, SystemExit) as e:
-    pass
+    nautilus_available = True
+except (ImportError, RuntimeError, SystemExit):
+    print("Bagpipes: Nautilus import failed, fitting with nautilus will be " +
+          "unavailable.")
+    nautilus_available = False
 
 # detect if run through mpiexec/mpirun
 try:
@@ -27,15 +31,8 @@ try:
     size = MPI.COMM_WORLD.Get_size()
     from mpi4py.futures import MPIPoolExecutor
 
-    if size == 1:
-        pool = None
-
-    else:
-        pool = MPIPoolExecutor(size)
-
 except ImportError:
     rank = 0
-    pool = None
 
 from .. import utils
 from .. import plotting
@@ -45,13 +42,15 @@ from .posterior import posterior
 
 
 class fit(object):
-    """ Top-level class for fitting models to observational data.
-    Interfaces with MultiNest to sample from the posterior distribution
-    of a fitted_model object. Performs loading and saving of results.
+    """
+    Top-level class for fitting models to observational data.
+
+    Interfaces with MultiNest or nautilus to sample from the posterior
+    distribution of a fitted_model object. Performs loading and saving of
+    results.
 
     Parameters
     ----------
-
     galaxy : bagpipes.galaxy
         A galaxy object containing the photomeric and/or spectroscopic
         data you wish to fit.
@@ -115,7 +114,9 @@ class fit(object):
         self.fitted_model = fitted_model(galaxy, self.fit_instructions,
                                          time_calls=time_calls)
 
-    def fit(self, verbose=False, n_live=400, use_MPI=True, sampler="multinest"):
+    def fit(self, verbose=False, n_live=400, use_MPI=True,
+            sampler="multinest", n_eff=0, discard_exploration=False,
+            n_networks=4, pool=4):
         """ Fit the specified model to the input galaxy data.
 
         Parameters
@@ -127,8 +128,26 @@ class fit(object):
         n_live : int - optional
             Number of live points: reducing speeds up the code but may
             lead to unreliable results.
-        """
 
+        sampler : string - optional
+            The sampler to use. Available options are "multinest" and
+            "nautilus".
+
+        n_eff : float - optional
+            Target minimum effective sample size. Only used by nautilus.
+
+        discard_exploration : bool - optional
+            Whether to discard the exploration phase to get more accurate
+            results. Only used by nautilus.
+
+        n_networks : int - optional
+            Number of neural networks. Only used by nautilus.
+
+        pool : int - optional
+            Pool size used for parallelization. Only used by nautilus.
+            MultiNest is parallelized with MPI.
+
+        """
         if "lnz" in list(self.results):
             if rank == 0:
                 print("Fitting not performed as results have already been"
@@ -136,6 +155,22 @@ class fit(object):
                       + " over delete this file or change run.\n")
 
             return
+
+        sampler = sampler.lower()
+
+        if (sampler == "multinest" and not multinest_available and
+                nautilus_available):
+            sampler = "nautilus"
+            print("MultiNest not available. Switching to nautilus.")
+        elif (sampler == "nautilus" and not nautilus_available and
+                multinest_available):
+            sampler = "multinest"
+            print("Nautilus not available. Switching to MultiNest.")
+        elif sampler not in ["multinest", "nautilus"]:
+            raise ValueError("Sampler {} not supported.".format(sampler))
+        elif not (multinest_available or nautilus_available):
+            raise RuntimeError(
+                "Neither MultiNest nor nautilus could be loaded.")
 
         if rank == 0 or not use_MPI:
             print("\nBagpipes: fitting object " + self.galaxy.ID + "\n")
@@ -155,12 +190,13 @@ class fit(object):
 
             elif sampler == "nautilus":
                 n_sampler = Sampler(self.fitted_model.prior.transform,
-                                        self.fitted_model.lnlike, n_live=n_live,
-                                        n_networks=1, pool=pool,
-                                        n_dim=self.fitted_model.ndim,
-                                        filepath=self.fname + "temp.h5")
+                                    self.fitted_model.lnlike, n_live=n_live,
+                                    n_networks=n_networks, pool=pool,
+                                    n_dim=self.fitted_model.ndim,
+                                    filepath=self.fname + "nautilus.h5")
 
-                n_sampler.run(verbose=verbose)
+                n_sampler.run(verbose=verbose, n_eff=n_eff,
+                              discard_exploration=discard_exploration)
 
         if rank == 0 or not use_MPI:
             runtime = time.time() - start_time
@@ -177,11 +213,12 @@ class fit(object):
                 self.results["lnz_err"] = float(lnz_line[-1])
 
             elif sampler == "nautilus":
-                samples2d, log_w, log_l = n_sampler.posterior(equal_weight=True)
+                samples2d, log_w, log_l = n_sampler.posterior(
+                    equal_weight=True)
                 self.results["samples2d"] = samples2d
                 self.results["lnlike"] = log_l
-                self.results["lnz"] = n_sampler.evidence()
-                self.results["lnz_err"] = -99
+                self.results["lnz"] = n_sampler.log_z
+                self.results["lnz_err"] = 1.0 / np.sqrt(n_sampler.n_eff)
 
             self.results["median"] = np.median(samples2d, axis=0)
             self.results["conf_int"] = np.percentile(self.results["samples2d"],

--- a/bagpipes/models/dust_emission_model.py
+++ b/bagpipes/models/dust_emission_model.py
@@ -36,13 +36,13 @@ class dust_emission(object):
 
         umin_w = np.array([(1 - umin_fact), umin_fact])
 
-        lqpah_only = config.dust_grid_umin_only[qpah_ind].data
-        hqpah_only = config.dust_grid_umin_only[qpah_ind+1].data
+        lqpah_only = config.dust_grid_umin_only[qpah_ind]
+        hqpah_only = config.dust_grid_umin_only[qpah_ind+1]
         tqpah_only = (qpah_fact*hqpah_only[:, umin_ind:umin_ind+2]
                       + (1-qpah_fact)*lqpah_only[:, umin_ind:umin_ind+2])
 
-        lqpah_umax = config.dust_grid_umin_umax[qpah_ind].data
-        hqpah_umax = config.dust_grid_umin_umax[qpah_ind+1].data
+        lqpah_umax = config.dust_grid_umin_umax[qpah_ind]
+        hqpah_umax = config.dust_grid_umin_umax[qpah_ind+1]
         tqpah_umax = (qpah_fact*hqpah_umax[:, umin_ind:umin_ind+2]
                       + (1-qpah_fact)*lqpah_umax[:, umin_ind:umin_ind+2])
 
@@ -52,7 +52,7 @@ class dust_emission(object):
         model = gamma*interp_umax + (1 - gamma)*interp_only
 
         spectrum = np.interp(self.wavelengths,
-                             config.dust_grid_umin_only[1].data[:, 0],
+                             config.dust_grid_umin_only[1][:, 0],
                              model, left=0., right=0.)
 
         return spectrum

--- a/bagpipes/models/nebular_model.py
+++ b/bagpipes/models/nebular_model.py
@@ -44,8 +44,8 @@ class nebular(object):
 
                 hdu_index = config.metallicities.shape[0]*j + i + 1
 
-                raw_cont_grid = config.cont_grid[hdu_index].data
-                raw_line_grid = config.line_grid[hdu_index].data
+                raw_cont_grid = config.cont_grid[hdu_index]
+                raw_line_grid = config.line_grid[hdu_index]
 
                 line_grid[:, i, j, :] = raw_line_grid[1:, 1:].T
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -29,7 +29,7 @@ Bagpipes is `developed at GitHub <https://github.com/ACCarnall/bagpipes>`_, howe
     pip install bagpipes
 
 
-All of the code's Python dependencies will be automatically installed. The only non-Python dependency is the MultiNest nested sampling algorithm (used only for fitting).
+All of the code's Python dependencies will be automatically installed. The only (optional) non-Python dependency is the MultiNest nested sampling algorithm (used only for fitting). Note that if MultiNest is not installed, Bagpipes will use the nautilus sampler for fitting, instead.
 
 The simplest way to install MultiNest if you have an anaconda python disribution is with the command **conda install -c conda-forge multinest**.
 
@@ -100,7 +100,7 @@ A few of the excellent projects Bagpipes relies on are:
  - The `MultiNest <https://ccpforge.cse.rl.ac.uk/gf/project/multinest>`_ nested sampling algorithm `(Feroz et al. 2013) <https://arxiv.org/abs/1306.2144>`_
  - The `PyMultiNest <https://johannesbuchner.github.io/PyMultiNest>`_ Python interface for Multinest `(Buchner et al. 2014) <https://arxiv.org/abs/1402.0004>`_.
  - The `Cloudy <https://www.nublado.org>`_ photoionization code `(Ferland et al. 2017) <https://arxiv.org/abs/1705.10877>`_.
-
+ - The `nautilus <https://nautilus-sampler.readthedocs.io/en/stable/>`_ importance nested sampling algorithm `(Lange 2023) <https://arxiv.org/abs/2306.16923>`_.
 
  .. toctree::
     :maxdepth: 1

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
 
     install_requires=["numpy", "corner", "pymultinest>=2.11", "h5py", "pandas",
                       "astropy", "matplotlib>=2.2.2", "scipy", "msgpack",
-                      "spectres"],
+                      "spectres", "nautilus-sampler>=1.0.2"],
 
     project_urls={
         "readthedocs": "https://bagpipes.readthedocs.io",


### PR DESCRIPTION
This PR enhances the integration of the nautilus sampler by making more options available to the user. I also updated the parallelization which was previously based on MPI and didn't quite work. The new parallelization scheme makes use of `multiprocessing`, i.e., doesn't require MPI and can easily be run in jupyter notebooks.

The PR also makes nautilus more prominent in bagpipes. I updated the documentation to reference nautilus. Additionally, nautilus was added as a dependency. Finally, bagpipes will now fall back on nautilus if MultiNest is not installed. This allows people to use bagpipes fitting seamlessly by just typing ​"pip install bagpipes" ​without having to compile and install MultiNest. But feel free to revert any of these changes.

The performance of nautilus is quite good. I ran [notebook 5](https://github.com/ACCarnall/bagpipes/blob/master/examples/Example%205%20-%20Fitting%20spectroscopic%20data.ipynb) from the examples. With nautilus (using 4 cores) the run took 10 minutes and ~80,000 model evaluations whereas MultiNest (no parallelization since that would be difficult with MPI in a notebook) took 2 hours and ~390,000 evaluations. That said, neither of the two samplers seem to give fully accurate results out of the box without tuning parameters.

Finally, note that I needed to make some slight changes to bagpipes/config.py and bagpipes/model to have nautilus parallelization work. Some data in bagpipes/config.py was stored as an HDU list which for some reason doesn't work with parallelization. The changes I made just amount to bagpipes/config.py storing the grids as numpy arrays instead of HDU tables. But please double-check I didn't introduce any errors.