### PR TITLE
Do not rename fitted model params if tex_on is False

### DIFF
--- a/bagpipes/plotting/plot_corner.py
+++ b/bagpipes/plotting/plot_corner.py
@@ -1,11 +1,9 @@
 from __future__ import print_function, division, absolute_import
 
 import numpy as np
-import copy
 
 try:
     import corner
-    import matplotlib as mpl
     import matplotlib.pyplot as plt
 
 except RuntimeError:

--- a/bagpipes/plotting/plot_corner.py
+++ b/bagpipes/plotting/plot_corner.py
@@ -27,7 +27,7 @@ def plot_corner(fit, show=False, save=True, bins=25, type="fit_params"):
         labels = fix_param_names(names)
 
     else:
-        labels = fit.fitted_model.params
+        labels = fit.fitted_model.params.copy()
 
     # Log any parameters with log_10 priors to make them easier to see
     for i in range(fit.fitted_model.ndim):


### PR DESCRIPTION
I recently ran into an issue where Bagpipes `fit_catalogue` (with `make_plots=True`) fails with a `KeyError` on systems without `latex`:

```
plot_1d_posterior.py:50, in plot_1d_posterior(fit, fit2, show, save)
---> 50 samples = np.copy(fit.posterior.samples[name])

KeyError: 'log_10(delayed:metallicity)'
```

The issue is that `fit.fitted_model.params` gets a *reference* to `labels`, which is later changed in place, thus changing the `params` names as well.

This PR fixes that issue by making `labels` a *copy* of the `params`.  It also removes two unused imports.