### PR TITLE
Replace (deprecated) distutils find_executable with shutil.which

### DIFF
--- a/bagpipes/plotting/general.py
+++ b/bagpipes/plotting/general.py
@@ -1,5 +1,7 @@
 from __future__ import print_function, division, absolute_import
 
+from shutil import which
+
 import numpy as np
 
 try:
@@ -9,12 +11,11 @@ try:
 except RuntimeError:
     pass
 
-from distutils.spawn import find_executable
 from scipy.ndimage import gaussian_filter
 
 from .. import utils
 
-tex_on = find_executable("latex")
+tex_on = which("latex")
 
 if not tex_on:
     print("Bagpipes: Latex distribution not found, plots may look strange.")


### PR DESCRIPTION
`distutils` has been deprecated for a while now (and completely removed from Python 3.12).  `setuptools` still packages a copy of `distutils`, but its usage is strongly discouraged.