### PR TITLE
Update dust_attenuation_model.py

### DIFF
--- a/bagpipes/models/dust_attenuation_model.py
+++ b/bagpipes/models/dust_attenuation_model.py
@@ -77,12 +77,12 @@ class dust_attenuation(object):
         Rv_m = 4.05/((4.05+1)*(4400./5500.)**delta - 4.05)
 
         drude = B*self.wavelengths**2*350.**2
-        drude /= (self.wavelengths**2 - 2175.**2)**2 + self.wavelengths**2*375.**2
+        drude /= (self.wavelengths**2 - 2175.**2)**2 + self.wavelengths**2*350.**2
         A_cont = self.A_cont_calz*Rv_m*(self.wavelengths/5500.)**delta + drude
         A_cont /= Rv_m
 
         drude = B*config.line_wavs**2*350.**2
-        drude /= (config.line_wavs**2 - 2175.**2)**2 + config.line_wavs**2*375.**2
+        drude /= (config.line_wavs**2 - 2175.**2)**2 + config.line_wavs**2*350.**2
         A_line = self.A_line_calz*Rv_m*(config.line_wavs/5500.)**delta + drude
         A_line /= Rv_m
 


### PR DESCRIPTION
I have been fitting models with the Salim+2018 dust attenuation model, and I noticed when looking at how this was implemented that the width of the bump feature is input at 375A on the denominator. 

I have updated this to 350A to be consistent across the implementation of the Drude profile and in line with the Salim+18 paper. 