### PR TITLE
Adding time-varying metallicity evolution, celerite SHOTerm GP noise kernel, VW07 dust law and minor patches

### DIFF
--- a/bagpipes/fitting/noise.py
+++ b/bagpipes/fitting/noise.py
@@ -7,6 +7,12 @@ try:
 except ImportError:
     pass
 
+try:
+    import celerite2
+    from celerite2 import terms
+
+except ImportError:
+    pass
 
 class noise_model(object):
     """ A class for modelling the noise properties of spectroscopic

--- a/bagpipes/fitting/noise.py
+++ b/bagpipes/fitting/noise.py
@@ -91,6 +91,38 @@ class noise_model(object):
 
         self.corellated = True
 
+    def GP_SHOTerm(self):
+        """ 
+        A GP noise model that uses celerite2's SHOTerm kernel 
+        for corellated noise and white noise (jitter term). 
+        This have been shown to be similar in behaviour to the
+        squared exponential kernel but at least 100x faster.
+        For more detail, see Leung et al. 2024
+        (https://ui.adsabs.harvard.edu/abs/2024MNRAS.528.4029L)
+        The kernel is implemented through Dan Foreman-Mackey's celerite2
+        For details, see https://celerite2.readthedocs.io/en/latest/ and
+        http://adsabs.harvard.edu/abs/2018RNAAS...2a..31F
+        """
+
+        scaling = self.param["scaling"]
+
+        # amplitude of the GP component
+        norm = self.param["norm"]
+        # the undamped period of the oscillator
+        period = self.param["period"]
+        # dampening quality factor Q
+        Q = self.param["Q"]
+
+        kernel = terms.SHOTerm(sigma=norm, rho=period, Q=Q)
+        self.gp = celerite2.GaussianProcess(kernel)
+        self.gp.compute(self.x, yerr=self.y_err*scaling)
+        # renaming the method gp.log_likelihood to gp.lnlikelihood 
+        # to be consistent with the old package george
+        # so _lnlike_spec in fitted_model.py does not need changing
+        self.gp.lnlikelihood = self.gp.log_likelihood
+
+        self.corellated = True
+
     def mean(self):
         if self.corellated:
             return self.max_y*self.gp.predict(self.diff, self.x,

--- a/bagpipes/models/chemical_enrichment_history.py
+++ b/bagpipes/models/chemical_enrichment_history.py
@@ -18,8 +18,15 @@ class chemical_enrichment_history(object):
 
         for comp in list(sfh_weights):
             if comp != "total":
-                self.grid_comp[comp] = self.delta(model_comp[comp],
-                                                  sfh_weights[comp])
+                if all(zmet_key not in model_comp[comp].keys() for zmet_key in ['metallicity_type', 'metallicity_scatter']):
+                    self.grid_comp[comp] = self.delta(model_comp[comp],
+                                                      sfh_weights[comp])
+                elif 'metallicity_type' in model_comp[comp].keys():
+                    self.grid_comp[comp] = getattr(self, model_comp[comp]['metallicity_type']
+                                                   )(model_comp[comp],sfh_weights[comp])
+                else:
+                    self.grid_comp[comp] = getattr(self, model_comp[comp]['metallicity_scatter']
+                                                   )(model_comp[comp],sfh_weights[comp])
 
                 self.grid += self.grid_comp[comp]
 
@@ -87,10 +94,11 @@ class chemical_enrichment_history(object):
 
         return grid*sfh
 
-    def delta(self, comp, sfh):
+    def delta(self, comp, sfh, zmet=None, nested=False):
         """ Delta function metallicity history. """
 
-        zmet = comp["metallicity"]
+        if zmet is None:
+            zmet = comp["metallicity"]
 
         weights = np.zeros(self.zmet_vals.shape[0])
 
@@ -108,12 +116,18 @@ class chemical_enrichment_history(object):
             weights[high_ind] = (zmet - self.zmet_vals[low_ind])/width
             weights[high_ind-1] = 1 - weights[high_ind]
 
-        return np.expand_dims(weights, axis=1)*np.expand_dims(sfh, axis=0)
+        if nested:
+            return weights
+        else:
+            return np.expand_dims(weights, axis=1)*np.expand_dims(sfh, axis=0)
 
-    def exp(self, comp, sfh):
+    def exp(self, comp, sfh, zmet=None, nested=False):
         """ P(Z) = exp(-z/z_mean). Currently no age dependency! """
 
-        mean_zmet = comp["metallicity"]
+        if zmet is None:
+            mean_zmet = comp["metallicity"]
+        else:
+            mean_zmet = zmet
 
         weights = np.zeros(self.zmet_vals.shape[0])
 
@@ -126,4 +140,135 @@ class chemical_enrichment_history(object):
             highmask = (vals_hr < self.zmet_lims[i+1])
             weights[i] = np.sum(0.01*factors_hr[lowmask & highmask])
 
+        if nested:
+            return weights
+        else:
+            return np.expand_dims(weights, axis=1)*np.expand_dims(sfh, axis=0)
+    
+    def lognorm(self, comp, sfh, zmet=None, nested=False):
+        """
+        log normal metallicity distribution of coeval stars. 
+        Functional form: P(x) = 1/(x*sigma*np.sqrt(2*np.pi)) * np.exp(-(np.log(x)-mu)**2/(2*sigma**2))
+        where mu = ln(metallicity mean), sigma = some concentration measurement
+        """
+        
+        if zmet is None:
+            log_mean_zmet = np.log(comp["metallicity"])
+        else:
+            log_mean_zmet = np.log(zmet)
+        sigma = 0.45
+
+        weights = np.zeros(self.zmet_vals.shape[0])
+
+        vals_hr = np.arange(0., 10., 0.01) + 0.005
+
+        factors_hr = 1/(vals_hr*sigma*np.sqrt(2*np.pi)) * np.exp(-(np.log(vals_hr)-log_mean_zmet)**2/(2*sigma**2))
+
+        for i in range(weights.shape[0]):
+            lowmask = (vals_hr > self.zmet_lims[i])
+            highmask = (vals_hr < self.zmet_lims[i+1])
+            weights[i] = np.sum(0.01*factors_hr[lowmask & highmask])
+
+        if nested:
+            return weights
+        else:
+            return np.expand_dims(weights, axis=1)*np.expand_dims(sfh, axis=0)
+
+    def constant(self, comp, sfh):
+        """ constant metallicity without any variation in time, distribution
+        of coeval stars can be specified thorugh 'metallicity_scatter'
+        """
+        
+        zmet = comp["metallicity"]
+        if "metallicity_scatter" not in comp.keys():
+            comp["metallicity_scatter"] = "delta"
+        
+        weights = getattr(self, comp['metallicity_scatter']
+                        )(comp, sfh, zmet=zmet, nested=True)
         return np.expand_dims(weights, axis=1)*np.expand_dims(sfh, axis=0)
+    
+    def two_step(self, comp, sfh):
+        """ 2-step metallicities (time-varying!) time of shift as free parameter """
+        
+        zmet_old = comp["metallicity_old"]
+        zmet_young = comp["metallicity_young"]
+        step_age = comp["metallicity_step_age"]*10**9
+        if "metallicity_scatter" not in comp.keys():
+            comp["metallicity_scatter"] = 'delta'
+        
+        # get SSP ages
+        SSP_ages = config.age_sampling
+        SSP_age_bins = config.age_bins
+        
+        # loop through all SSP ages
+        zmet_comp = np.zeros((self.zmet_vals.shape[0], sfh.shape[0]))
+        for i,agei in enumerate(SSP_ages):
+            # detect if the SSP age's higher boundary > step_age and lower boundary < step_age
+            if SSP_age_bins[i+1]>step_age and SSP_age_bins[i]<step_age:
+                # interp between to get metallicity at this SSP
+                width = SSP_age_bins[i+1] - SSP_age_bins[i]
+                old_weight = (SSP_age_bins[i+1] - step_age)/width
+                burst_weight = (step_age - SSP_age_bins[i])/width
+                SSP_zmet = old_weight*zmet_old + burst_weight*zmet_young
+                # weights from metallicity scatter
+                zmet_comp[:,i] = getattr(self, comp['metallicity_scatter']
+                                        )(comp, sfh, zmet=SSP_zmet, nested=True)
+            
+            # if before step_age
+            elif SSP_age_bins[i]>step_age:
+                # weights from metallicity scatter
+                zmet_comp[:,i] = getattr(self, comp['metallicity_scatter']
+                                        )(comp, sfh, zmet=zmet_old, nested=True)
+                
+            # if after step_age
+            elif SSP_age_bins[i+1]<step_age:
+                # weights from metallicity scatter
+                zmet_comp[:,i] = getattr(self, comp['metallicity_scatter']
+                                        )(comp, sfh, zmet=zmet_young, nested=True)
+            
+        return zmet_comp*np.expand_dims(sfh, axis=0)
+    
+    def psb_two_step(self, comp, sfh):
+        """ 
+        2-step metallicities (time-varying!) for psb_wild2020 SFH model, shift at burstage
+        For details, see Leung et al. 2024 
+        (https://ui.adsabs.harvard.edu/abs/2024MNRAS.528.4029L)
+        """
+        
+        zmet_old = comp["metallicity_old"]
+        zmet_burst = comp["metallicity_burst"]
+        burstage = comp["burstage"]*10**9
+        if "metallicity_scatter" not in comp.keys():
+            comp["metallicity_scatter"] = 'delta'
+        
+        # get SSP ages
+        SSP_ages = config.age_sampling
+        SSP_age_bins = config.age_bins
+        
+        # loop through all SSP ages
+        zmet_comp = np.zeros((self.zmet_vals.shape[0], sfh.shape[0]))
+        for i,agei in enumerate(SSP_ages):
+            # detect if the SSP age's higher boundary > tburst and lower boundary < tburst
+            if SSP_age_bins[i+1]>burstage and SSP_age_bins[i]<burstage:
+                # interp between to get metallicity at this SSP
+                width = SSP_age_bins[i+1] - SSP_age_bins[i]
+                old_weight = (SSP_age_bins[i+1] - burstage)/width
+                burst_weight = (burstage - SSP_age_bins[i])/width
+                SSP_zmet = old_weight*zmet_old + burst_weight*zmet_burst
+                # weights from metallicity scatter
+                zmet_comp[:,i] = getattr(self, comp['metallicity_scatter']
+                                        )(comp, sfh, zmet=SSP_zmet, nested=True)
+            
+            # if before tburst
+            elif SSP_age_bins[i]>burstage:
+                # weights from metallicity scatter
+                zmet_comp[:,i] = getattr(self, comp['metallicity_scatter']
+                                        )(comp, sfh, zmet=zmet_old, nested=True)
+                
+            # if after tburst
+            elif SSP_age_bins[i+1]<burstage:
+                # weights from metallicity scatter
+                zmet_comp[:,i] = getattr(self, comp['metallicity_scatter']
+                                        )(comp, sfh, zmet=zmet_burst, nested=True)
+        
+        return zmet_comp*np.expand_dims(sfh, axis=0)

--- a/bagpipes/models/model_galaxy.py
+++ b/bagpipes/models/model_galaxy.py
@@ -405,7 +405,10 @@ class model_galaxy(object):
             if "eta" in list(model_comp["dust"]):
                 eta = model_comp["dust"]["eta"]
                 bc_Av_reduced = (eta - 1.)*model_comp["dust"]["Av"]
-                bc_trans_red = 10**(-bc_Av_reduced*self.dust_atten.A_cont/2.5)
+                if self.dust_atten.two_component:
+                    bc_trans_red = 10**(-bc_Av_reduced*self.dust_atten.A_cont_bc/2.5)
+                else:
+                    bc_trans_red = 10**(-bc_Av_reduced*self.dust_atten.A_cont/2.5)
                 spectrum_bc_dust = spectrum_bc*bc_trans_red
                 dust_flux += np.trapz(spectrum_bc - spectrum_bc_dust,
                                       x=self.wavelengths)

--- a/bagpipes/models/star_formation_history.py
+++ b/bagpipes/models/star_formation_history.py
@@ -128,15 +128,14 @@ class star_formation_history:
         self.sfr = np.sum(self.sfh[age_mask]*self.age_widths[age_mask])
         self.sfr /= self.age_widths[age_mask].sum()
 
-        # ssfr and nsfr: set sfr=0 as nan to avoid divide by 0 warning
-        self.ssfr = np.empty(self.sfr.shape)
-        self.ssfr[:] = np.nan
-        self.ssfr[self.sfr>0] = np.log10(self.sfr[self.sfr>0]) - self.stellar_mass
-
-        self.nsfr = np.empty(self.sfr.shape)
-        self.nsfr[:] = np.nan
-        self.nsfr[self.sfr>0] = np.log10(self.sfr[self.sfr>0]*self.age_of_universe) - self.stellar_mass
-
+        # ssfr and nsfr: if sfr=0, set as nan to avoid divide by 0 warning
+        if self.sfr == 0:
+            self.ssfr = np.nan
+            self.nsfr = np.nan
+        else:
+            self.ssfr = np.log10(self.sfr) - self.stellar_mass
+            self.nsfr = np.log10(self.sfr*self.age_of_universe) - self.stellar_mass
+        
         self.mass_weighted_age = np.sum(self.sfh*self.age_widths*self.ages)
         self.mass_weighted_age /= np.sum(self.sfh*self.age_widths)
 

--- a/bagpipes/models/star_formation_history.py
+++ b/bagpipes/models/star_formation_history.py
@@ -127,8 +127,15 @@ class star_formation_history:
         age_mask = (self.ages < config.sfr_timescale)
         self.sfr = np.sum(self.sfh[age_mask]*self.age_widths[age_mask])
         self.sfr /= self.age_widths[age_mask].sum()
-        self.ssfr = np.log10(self.sfr) - self.stellar_mass
-        self.nsfr = np.log10(self.sfr*self.age_of_universe) - self.formed_mass
+
+        # ssfr and nsfr: set sfr=0 as nan to avoid divide by 0 warning
+        self.ssfr = np.empty(self.sfr.shape)
+        self.ssfr[:] = np.nan
+        self.ssfr[self.sfr>0] = np.log10(self.sfr[self.sfr>0]) - self.stellar_mass
+
+        self.nsfr = np.empty(self.sfr.shape)
+        self.nsfr[:] = np.nan
+        self.nsfr[self.sfr>0] = np.log10(self.sfr[self.sfr>0]*self.age_of_universe) - self.stellar_mass
 
         self.mass_weighted_age = np.sum(self.sfh*self.age_widths*self.ages)
         self.mass_weighted_age /= np.sum(self.sfh*self.age_widths)


### PR DESCRIPTION
I have added some extra functionalities to the models, namely:
- metallicity: two-step metallicity evolution, post-starburst two-step metallicity evolution, lognormal distribution in metallicity of coeval stars
- noise: celerite2 SHOTerm GP noise kernel for shorter time per likelihood evaluation
- dust: Two component dust law from Wild+2007 where stars < 10Myr year old and nebular lines have CF00 dust curve with n=1.3, while older stars have CF00 dust curve with n=0.7

And changed some lines of code in star_formation_history.py that were triggering numpy warnings.