### PR TITLE
Fix encoding issue in np.genfromtxt

### DIFF
--- a/bagpipes/fitting/fit.py
+++ b/bagpipes/fitting/fit.py
@@ -72,11 +72,10 @@ def _read_multinest_data(filename):
     # '0.148232-104'  -> 1.482320e-105
     # '0.148232E-10'  -> 1.482320e-011
     # '1.148232'      -> 1.48232e+000
-    convert = lambda s: float(re.sub(r'(\d)([\+\-])(\d)', r'\1E\2\3',
-                                     s.decode()))
+    convert = lambda s: float(re.sub(r'(\d)([\+\-])(\d)', r'\1E\2\3', s))
     converters = dict(zip(range(ncolumns), [convert] * ncolumns))
 
-    return np.genfromtxt(filename, converters=converters)
+    return np.genfromtxt(filename, converters=converters, encoding=None)
 
 
 class fit(object):


### PR DESCRIPTION
Hi Adam,

Sorry for being back with another issue already – this is just a very minor one, I found with my new install that the behaviour of `np.genfromtxt` has changed in Numpy v2.0 (https://numpy.org/doc/stable/reference/generated/numpy.genfromtxt.html), switching from having `encoding='bytes'` as default to `encoding=None`.

This causes the code to crash when attempting to read in the MultiNest results, which is avoided by explicitly setting `encoding=None` and removing the decoding bit. I think this should also work with older Numpy versions, still have to double check though!

Cheers,
Joris