### PR TITLE
Feature: add function to print all the available model components

### DIFF
--- a/bagpipes/models/__init__.py
+++ b/bagpipes/models/__init__.py
@@ -13,3 +13,14 @@ from .igm_model import igm
 from .model_galaxy import model_galaxy
 from .star_formation_history import star_formation_history
 from .chemical_enrichment_history import chemical_enrichment_history
+
+def list_available_components():
+    """Return a dictionary of available component types and their classes."""
+    return {
+        'dust_emission': dust_emission.list_available_dust_emission_components(),
+        'dust_attenuation': dust_attenuation.list_available_dust_attenuation_components(),
+        'agn': agn.list_available_agn_components(),
+        'nebular': nebular.list_available_nebular_components(),
+        'star_formation_history': star_formation_history.list_available_sfh_components(),
+        'chemical_enrichment_history': chemical_enrichment_history.list_available_ceh_components()
+    }

--- a/bagpipes/models/agn_model.py
+++ b/bagpipes/models/agn_model.py
@@ -15,6 +15,7 @@ class agn(object):
     param : dict
         Parameters for the AGN model.
     """
+    __all__ = ['alphalam', 'betalam', 'f5100A', 'hanorm', 'sigma']
 
     def __init__(self, wavelengths):
         self.wavelengths = wavelengths
@@ -52,3 +53,7 @@ class agn(object):
         gauss *= np.exp(-0.5*(x-central_wav)**2/sigma_aa**2)
 
         return gauss
+
+    @classmethod
+    def list_available_agn_components(cls):
+        return getattr(cls, '__all__', [])  # Safe fallback if __all__ missing

--- a/bagpipes/models/chemical_enrichment_history.py
+++ b/bagpipes/models/chemical_enrichment_history.py
@@ -6,6 +6,8 @@ from .. import config
 
 
 class chemical_enrichment_history(object):
+    __all__ = ['delta', 'metallicity_bins', 'metallicity_bins_continuity',
+               'exp', 'lognorm', 'constant', 'two_step', 'psb_two_step']
 
     def __init__(self, model_comp, sfh_weights):
 
@@ -300,3 +302,8 @@ class chemical_enrichment_history(object):
                                             nested=True)
 
         return zmet_comp*np.expand_dims(sfh, axis=0)
+
+    @staticmethod    
+    def list_available_ceh_components():
+        """Return list of available chemical enrichment history component types."""
+        return getattr(chemical_enrichment_history, '__all__', [])  # Safe fallback if __all__ missing  

--- a/bagpipes/models/dust_attenuation_model.py
+++ b/bagpipes/models/dust_attenuation_model.py
@@ -26,6 +26,7 @@ class dust_attenuation(object):
     type : str
         The type of dust model.
     """
+    __all__ = ['Calzetti', 'Cardelli', 'SMC', 'Salim', 'VW07']
 
     def __init__(self, wavelengths, param):
         self.wavelengths = wavelengths
@@ -232,3 +233,8 @@ class dust_attenuation(object):
         plt.show()
         """
         return A_lambda
+
+    @classmethod
+    def list_available_dust_attenuation_components(cls):
+        """Return list of available dust attenuation component types."""
+        return getattr(cls, '__all__', [])  # Safe fallback if __all__ missing

--- a/bagpipes/models/dust_emission_model.py
+++ b/bagpipes/models/dust_emission_model.py
@@ -17,6 +17,8 @@ class dust_emission(object):
         1D array of wavelength values desired for the DL07 models.
     """
 
+    __all__ = ['qpah', 'umin', 'gamma']
+
     def __init__(self, wavelengths):
         self.wavelengths = wavelengths
 
@@ -57,3 +59,8 @@ class dust_emission(object):
 
         spectrum_norm = spectrum / np.trapz(spectrum, x=self.wavelengths)
         return spectrum_norm
+
+    @classmethod
+    def list_available_dust_emission_components(cls):
+        """Return list of available dust emission component types."""
+        return getattr(cls, '__all__', [])  # Safe fallback if __all__ missing

--- a/bagpipes/models/nebular_model.py
+++ b/bagpipes/models/nebular_model.py
@@ -17,6 +17,7 @@ class nebular(object):
     wavelengths : np.ndarray
         1D array of wavelength values desired for the stellar models.
     """
+    __all__ = ['velshift']
 
     def __init__(self, wavelengths, velshift):
         self.wavelengths = wavelengths
@@ -139,3 +140,8 @@ class nebular(object):
                     + spectrum_low_logU*logU_weight)
 
         return spectrum
+
+    @classmethod
+    def list_available_nebular_components(cls):
+        # check if function has a return statement
+        return getattr(cls, '__all__', [])  # Safe fallback if __all__ missing

--- a/bagpipes/models/star_formation_history.py
+++ b/bagpipes/models/star_formation_history.py
@@ -45,6 +45,11 @@ class star_formation_history:
     log_sampling : float - optional
         the log of the age sampling of the SFH, defaults to 0.0025.
     """
+    __all__ = [
+        'burst', 'constant', 'exponential', 'delayed', 'lognormal',
+        'dblplaw', 'iyer', 'continuity', 'custom', 'const_exp', 
+        'iyer2019', 'psb_wild2020'
+    ]
 
     def __init__(self, model_components, log_sampling=0.0025):
 
@@ -371,3 +376,8 @@ class star_formation_history:
 
     def plot(self, show=True):
         return plotting.plot_sfh(self, show=show)
+
+    @classmethod
+    def list_available_sfh_components(cls):
+        """Return list of available star formation history component types."""
+        return getattr(cls, '__all__', [])  # Safe fallback if __all__ missing

--- a/docs/model_components.rst
+++ b/docs/model_components.rst
@@ -112,3 +112,7 @@ Four dust attenuation models are implemented in Bagpipes, the Calzetti et al. (2
 	dust["qpah"] = 2.          # PAH mass fraction
 	dust["umin"] = 1.          # Lower limit of starlight intensity distribution
 	dust["gamma"] = 0.01       # Fraction of stars at umin
+
+
+To view a higher level summary of the available model components, 
+see the `list_available_components` function in the documentation for the ``bagpipes.models`` module.

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
 
     packages=["bagpipes", "bagpipes.fitting", "bagpipes.catalogue",
               "bagpipes.models", "bagpipes.filters", "bagpipes.input",
-              "bagpipes.plotting", "bagpipes.models.making", "bagpipes.moons"],
+              "bagpipes.plotting", "bagpipes.models.making"],
 
     include_package_data=True,
 


### PR DESCRIPTION
Since there was no function to see all the available toggles that can go into the `model_components` dictionary, this is a PR to solve that.

Now we can do 
```python
import bagpipes.models as models

print(models.list_available_components())
```

And get the output as follows:

```bash
{'dust_emission': ['qpah', 'umin', 'gamma'], 'dust_attenuation': ['Calzetti', 'Cardelli', 'SMC', 'Salim', 'VW07'], 'agn': ['alphalam', 'betalam', 'f5100A', 'hanorm', 'sigma'], 'nebular': ['velshift'], 'star_formation_history': ['burst', 'constant', 'exponential', 'delayed', 'lognormal', 'dblplaw', 'iyer', 'continuity', 'custom', 'const_exp', 'iyer2019', 'psb_wild2020'], 'chemical_enrichment_history': ['delta', 'metallicity_bins', 'metallicity_bins_continuity', 'exp', 'lognorm', 'constant', 'two_step', 'psb_two_step']}
```
