### PR TITLE
Update fit_catalogue.py

### DIFF
--- a/bagpipes/catalogue/fit_catalogue.py
+++ b/bagpipes/catalogue/fit_catalogue.py
@@ -162,7 +162,7 @@ class fit_catalogue(object):
             if os.path.exists(cat_file):
                 self.cat = Table.read(cat_file).to_pandas()
                 self.cat.index = self.IDs
-                self.done = (self.cat.loc[:, "log_evidence"] != 0.).values
+                self.done = np.array(self.cat.loc[:, "log_evidence"] != 0.)
 
         if size > 1 and mpi_serial:
             self._fit_mpi_serial(n_live=n_live, track_backlog=track_backlog)


### PR DESCRIPTION
This line throws the following error in my environment with `pandas==3.0.3` and `numpy==2.4.6` (and this is the only line which has caused any problems with those two package versions):
```  
Traceback (most recent call last):
  File "/media/sharedData/python/py3.13_PIE/code/PASSAGE_scripts/3__SED_fitting/run_fits.py", line 214, in <module>
    cat_fit.fit(n_live=400, verbose=True, mpi_serial=False, track_backlog=True)
    ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/media/sharedData/python/py3.13_PIE/lib/python3.13/site-packages/bagpipes/catalogue/fit_catalogue.py", line 190, in fit
    self.done[i] = True
    ~~~~~~~~~^^^
ValueError: assignment destination is read-only
```

I'm pretty sure this is the new pandas 3.0 copy-on-write behaviour (or less likely, some other minor update to numpy that I overlooked), so creating `self.done` explicitly as a numpy array solves the problem.